### PR TITLE
Fix: prepend the KO_DOCKER_REPOSITORY to the base docker build to allow local publishing of the controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ bump-version:
 
 # Build the docker image
 docker-build:
-	${ENGINE} buildx build ${ARCH} . -t ${IMG}
+	${ENGINE} buildx build ${ARCH} . -t ${KO_DOCKER_REPO}/${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 
 	# Use perl instead of sed to avoid OSX/Linux compatibility issue:
@@ -322,7 +322,7 @@ docker-build:
 
 # Push the docker image
 docker-push:
-	docker push ${IMG}
+	docker push ${KO_DOCKER_REPO}/${IMG}
 
 docker-build-llmisvc:
 	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${LLMISVC_IMG} -f llmisvc-controller.Dockerfile .


### PR DESCRIPTION

**What this PR does / why we need it**:

When building the docker containers for local debugging in kind the controller reuses the docker hub upstream container tag.  This fix allows the controller images to push to the KO_DOCKER_REPO like the other targets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- build locally against kind
- build in CI

```release-note
None
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.